### PR TITLE
Allow hyphens in prometheus ids

### DIFF
--- a/src/main/scala/AppConfig.scala
+++ b/src/main/scala/AppConfig.scala
@@ -98,7 +98,7 @@ object AppConfig {
   }
 
   private[greenish] def normalizePrometheusId(id: String): String = {
-    val spacelessId = id.replaceAll("\\s+","_").toLowerCase
+    val spacelessId = id.replaceAll("(\\s|-)+","_").toLowerCase
     val pattern = "[a-zA-Z_][a-zA-Z0-9_]*"
     if(!spacelessId.matches(pattern)) {
       throw new Exception(

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -93,7 +93,7 @@ check-groups: {
           #
           # In case this option is skipped, the combination of `group` and
           # `job` name is chosen, turned into lower-case and all the whitespace
-          # characters are replaced with _.
+          # characters, and hyphens are replaced with _.
           # Prometheus IDs should match this pattern:
           # "[a-zA-Z_][a-zA-Z0-9_]*"
           prometheus-id: "job_1"

--- a/src/test/scala/AppConfigSpec.scala
+++ b/src/test/scala/AppConfigSpec.scala
@@ -90,6 +90,10 @@ class AppConfigSpec() extends Matchers
       normalizePrometheusId("ABC") shouldBe "abc"
     }
 
+    "replace - characters in prometheus_id to _" in {
+      normalizePrometheusId("a---b") shouldBe "a_b"
+    }
+
     "replace whitesapce characters in prometheus_id to _" in {
       normalizePrometheusId("a b\nc\td\t") shouldBe "a_b_c_d_"
     }


### PR DESCRIPTION
Replaces them with underscore. This is useful, so you can have hyphen in
job names, and still be able to get prometheus ids out of the job names